### PR TITLE
DESENG-54 Removing the strict engine requirement for now.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-engine-strict=true
+# engine-strict=true

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "database-cleaner": "^1.2.0",
-    "eslint": "^8.7.0",
+    "eslint": "^7.0.0",
     "factory-girl": "^5.0.2",
     "jest": "^23.6.0",
     "mongodb-memory-server": "^2.6.2",


### PR DESCRIPTION
The last commit caused another issue when the devDependencies used a version of eslint that is incompatible with node ^10.0.0. I'm going to comment out the strict node engine check for now since I've removed the original offending code anyway(optional object chaining).

A ticket will be created in the future to lock down the node engine version as best as possible.