### PR TITLE
DESENG-13 Added dotenv to devDependencies by accident

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clamav.js": "^0.12.0",
     "crypto": "^1.0.1",
     "csv": "^5.1.1",
+    "dotenv": "^16.0.0",
     "epsg": "^0.5.0",
     "express": "^4.16.0",
     "flake-idgen": "^1.1.0",
@@ -72,7 +73,6 @@
   },
   "devDependencies": {
     "database-cleaner": "^1.2.0",
-    "dotenv": "^16.0.0",
     "eslint": "^7.0.0",
     "factory-girl": "^5.0.2",
     "jest": "^23.6.0",


### PR DESCRIPTION
I installed the dotenv dependency in the wrong place and it's causing the API to crash.

CHANGELOG updated previously