### PR TITLE
bugfix/deseng889: Fixed crashes that can't restart: Changed default start script, modified deployment yamls for test and prod server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Aug 26, 2025
+* Fixed API state hang that prevents container restarts when a fatal error occurs. [DESENG-889](https://citz-gdx.atlassian.net/browse/DESENG-889)
+
 ### Aug 1, 2025
 * Remove unused comment properties that were causing a crash when approving rejecting comments [DESENG-888](https://citz-gdx.atlassian.net/browse/DESENG-888)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ API for the Land Use Planning [Public](https://github.com/bcgov/landuseplanning-
 - Those related to Mongo correspond to the docker-compose file found in the `db` directory.
 - SILENCE_DEFAULT_LOG is used for local development only. See [Logging](#logging) below.
 3. Run `npm i` to install.
-4. Run `npm start` to start the development environment. 
+4. Run `npm run dev` to start the development environment. 
 
 ## Technologies used
 

--- a/openshift/templates/landuseplanning-api-prod-deploy.yaml
+++ b/openshift/templates/landuseplanning-api-prod-deploy.yaml
@@ -26,7 +26,8 @@ spec:
         - name: landuseplanning-api-prod
           image: image-registry.apps.silver.devops.gov.bc.ca/e8b9ad-tools/landuseplanning-api:prod
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 3000
               protocol: TCP
           env:
             - name: KEYCLOAK_ENABLED
@@ -90,6 +91,26 @@ spec:
             - name: ENABLE_VIRUS_SCANNING
               value: 'true'
           resources: {}
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 3
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 5
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: Always

--- a/openshift/templates/landuseplanning-api-test-deploy.yaml
+++ b/openshift/templates/landuseplanning-api-test-deploy.yaml
@@ -26,7 +26,8 @@ spec:
         - name: landuseplanning-api-test
           image: image-registry.apps.silver.devops.gov.bc.ca/e8b9ad-tools/landuseplanning-api:test
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 3000
               protocol: TCP
           env:
             - name: KEYCLOAK_ENABLED
@@ -90,6 +91,26 @@ spec:
             - name: API_HOSTNAME
               value: landuseplanning-test.apps.silver.devops.gov.bc.ca
           resources: {}
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 3
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 5
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: Always

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   },
   "scripts": {
     "preinstall": "npm install --package-lock-only --ignore-scripts",
-    "start": "nodemon app",
+    "start": "node app.js",
+    "dev": "nodemon app",
     "lint": "eslint api/controllers/*.js api/helpers/**/*.js api/test/*.js api/test/**/*.js",
     "test": "UPLOAD_DIRECTORY='./api/test/uploads/' jest --runInBand",
     "tests-debug": "node --inspect node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
Bugfix/deseng889: Fixed crashes that can't restart: 

- Changed default start script in package.json
- modified deployment .yamls for test and prod server
    - Corrected port settings
    - Added readinessProbes and livenessProbes

Ticket: https://citz-gdx.atlassian.net/browse/DESENG-889