### PR TITLE
DESENG-921: Fixes and enhancements for multi-project email confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Nov 5, 2025
+* Update email subscribe confirmation ([DESENG-921](https://citz-gdx.atlassian.net/browse/DESENG-921))
+    * Fix an issue where subscribing to multiple projects would create invalid confirmation links
+    * Finish implementation of adding projects to existing confirmed subscriptions
+    * Send "project added" email when a confirmed subscriber adds a new project
+    * Update email templates to clarify what action the user is taking
+    * Clean up existing code, comments, and logging in email.js and emailSubscribe.js
+
 ### Aug 26, 2025
 * Fixed API state hang that prevents container restarts when a fatal error occurs. [DESENG-889](https://citz-gdx.atlassian.net/browse/DESENG-889)
 

--- a/api/controllers/emailSubscribe.js
+++ b/api/controllers/emailSubscribe.js
@@ -4,6 +4,7 @@ var mongoose = require('mongoose');
 var Actions = require('../helpers/actions');
 var Utils = require('../helpers/utils');
 var Email = require('../helpers/email');
+const randToken = require('rand-token');
 const csv = require('csv');
 const transform = require('stream-transform');
 const ENABLE_VIRUS_SCANNING = process.env.ENABLE_VIRUS_SCANNING || false;
@@ -86,6 +87,7 @@ const fetchProjectNames = async (ProjectModel, projectIds, fallbackName) => {
   // Map IDs to names while maintaining order
   const names = orderedIds
     .map(id => projectMap.get(id))
+    // throw out any undefined project names (in case of missing projects)
     .filter(Boolean);
 
   if (names.length === 0 && fallbackName) {
@@ -99,15 +101,15 @@ const fetchProjectNames = async (ProjectModel, projectIds, fallbackName) => {
 exports.unProtectedPost = async function (args, res) {
   defaultLog.info('EMAIL SUBSCRIBE PUBLIC POST');
 
-  const obj = args.swagger.params.emailSubscribe.value;
-  const requestedEmail = obj.email;
+  const subscriptionRequest = args.swagger.params.emailSubscribe.value;
+  const requestedEmail = subscriptionRequest.email;
   const sendGenericSuccess = () => Actions.sendResponse(res, 200, { message: 'Subscription request processed' });
 
   let requestedProjectId;
   try {
-    requestedProjectId = mongoose.Types.ObjectId(obj.project);
+    requestedProjectId = mongoose.Types.ObjectId(subscriptionRequest.project);
   } catch (err) {
-    defaultLog.warn('Invalid project identifier supplied for subscription', { email: requestedEmail, project: obj.project });
+    defaultLog.warn('Invalid project identifier supplied for subscription', { email: requestedEmail, project: subscriptionRequest.project });
     return sendGenericSuccess();
   }
 
@@ -125,6 +127,8 @@ exports.unProtectedPost = async function (args, res) {
       _schemaName: 'EmailSubscribe',
       email: requestedEmail
     });
+
+    let subscriptionChanged = false;
 
     // Case 1: No existing subscription - create new record and send confirmation email
     if (!subscription) {
@@ -155,8 +159,6 @@ exports.unProtectedPost = async function (args, res) {
       projId => projId && projId.toString() === requestedProjectId.toString()
     );
 
-    let subscriptionChanged = false;
-
     if (!alreadySubscribedToProject) {
       subscription.project.push(requestedProjectId);
       subscriptionChanged = true;
@@ -164,6 +166,14 @@ exports.unProtectedPost = async function (args, res) {
 
     // Handle unconfirmed subscriptions
     if (!subscription.confirmed) {
+      if (!subscription.confirmKey) {
+        subscription.confirmKey = randToken.generate(64);
+        subscriptionChanged = true;
+        defaultLog.info('Generated missing confirmation key for existing subscription', {
+          subscriptionId: subscription._id
+        });
+      }
+
       const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
       const twentyFourHoursAgo = new Date(now.getTime() - TWENTY_FOUR_HOURS_MS);
       const shouldSendConfirmEmail = !subscription.dateSubscribed || subscription.dateSubscribed <= twentyFourHoursAgo;
@@ -258,7 +268,7 @@ exports.unProtectedPut = async function (args, res) {
 
     if (subscription.confirmed) {
       defaultLog.info('Email already confirmed', { email: emailAddress, subscriptionId: subscription._id });
-      return Actions.sendResponse(res, 200, { message: 'Email already confirmed' });
+      return sendGenericSuccess(); // Prevent account enumeration
     }
 
     // Confirm the subscription

--- a/api/controllers/emailSubscribe.js
+++ b/api/controllers/emailSubscribe.js
@@ -26,7 +26,7 @@ var getSanitizedFields = function (fields) {
       'delete'
     ], f) !== -1);
   });
-}
+};
 
 exports.protectedOptions = function (args, res) {
   defaultLog.info('EMAIL SUBSCRIBE PROTECTED OPTIONS');
@@ -59,177 +59,231 @@ exports.publicHead = async function (args, res) {
   return Actions.sendResponse(res, 200, data);
 };
 
+/**
+ * Fetch project names from the database, maintaining the order of provided IDs.
+ * 
+ * @param {Model} ProjectModel Mongoose Project model
+ * @param {ObjectId[]} projectIds Array of project ObjectIds
+ * @param {string} fallbackName Optional fallback name if no projects found
+ * @returns {Promise<string[]>} Array of project names in the same order as input IDs
+ */
+const fetchProjectNames = async (ProjectModel, projectIds, fallbackName) => {
+  if (!Array.isArray(projectIds) || projectIds.length === 0) {
+    return fallbackName ? [fallbackName] : [];
+  }
+
+  const orderedIds = projectIds.map(id => id && id.toString()).filter(Boolean);
+  if (orderedIds.length === 0) {
+    return fallbackName ? [fallbackName] : [];
+  }
+
+  const uniqueIds = [...new Set(orderedIds)];
+  const projects = await ProjectModel.find({ _id: { $in: uniqueIds } }, { name: 1 }).lean();
+
+  // Create a map for O(1) lookup
+  const projectMap = new Map(projects.map(p => [p._id.toString(), p.name]));
+
+  // Map IDs to names while maintaining order
+  const names = orderedIds
+    .map(id => projectMap.get(id))
+    .filter(Boolean);
+
+  if (names.length === 0 && fallbackName) {
+    return [fallbackName];
+  }
+
+  return names;
+};
+
 // subscribe a new email address
 exports.unProtectedPost = async function (args, res) {
   defaultLog.info('EMAIL SUBSCRIBE PUBLIC POST');
-  let obj = args.swagger.params.emailSubscribe.value;
-  defaultLog.info('Incoming new object:', obj);
-  let existingEmailId, alreadyConfirmed, confirmKey;
-  let projectName = 'Planning in Partnership';
-  let isDuplicate = false;
 
-  let EmailSubscribe = mongoose.model('EmailSubscribe');
-  let Project = mongoose.model('Project');
+  const obj = args.swagger.params.emailSubscribe.value;
+  const requestedEmail = obj.email;
+  const sendGenericSuccess = () => Actions.sendResponse(res, 200, { message: 'Subscription request processed' });
 
-  let emailSubscribe = new EmailSubscribe(obj);
-  emailSubscribe._schemaName = 'EmailSubscribe';
-  emailSubscribe.email = obj.email;
-  emailSubscribe.project = [mongoose.Types.ObjectId(obj.project)];
-  emailSubscribe.confirmed = false;
-  emailSubscribe.dateSubscribed = new Date();
-  emailSubscribe.dateConfirmed = null;
-  emailSubscribe.read = ['staff', 'sysadmin'];
-  emailSubscribe.write = ['staff', 'sysadmin'];
-  emailSubscribe.delete = ['staff', 'sysadmin'];
-
-  // get the project name
-  await Project.findOne({ _id: obj.project }, null, async function (err, entity) {
-    if (entity) {
-      projectName = entity.name;
-    }
-  });
-
-  // check if already exists
-  // if so either update with the new project or exit gracefully
-  await EmailSubscribe.findOne({ _schemaName: 'EmailSubscribe', email: emailSubscribe.email }, null, async function (err, entity) {
-    if (entity) {
-      existingEmailId = entity._id;
-      existingProjectArray = entity.project;
-      alreadyConfirmed = entity.confirmed;
-      confirmKey = entity.confirmKey;
-      // check if pushed project is in array
-      if (existingProjectArray.includes(mongoose.Types.ObjectId(obj.project)) ) {
-        isDuplicate = true;
-      }
-    }
-
-    if (existingEmailId && isDuplicate ) {
-      // Project and email already exists so exit gracefully
-      defaultLog.info('User has already signed up for the project', existingEmailId);
-      return Actions.sendResponse(res, 200, '200');
-    } else if (existingEmailId) {
-      // New project for an existing email
-      existingProjectArray.push(mongoose.Types.ObjectId(obj.project));
-      await EmailSubscribe.updateOne({ _id: existingEmailId }, { $set: { project: existingProjectArray } }, async function (err, entity) {
-        if (err) throw new Error(err);
-        if (entity) {
-          Utils.recordAction('Put', 'EmailSubscribe', 'public', existingEmailId);
-          defaultLog.info('New project added to email subscribe:', entity._id);
-        }
-      });
-      // have they already confirmed their email?
-      // if so, send the welcome for the new project
-      if (alreadyConfirmed) {
-        defaultLog.info('Email was already confirmed - sending welcome email for project/email', projectName, emailSubscribe.email);
-        await Email.sendWelcomeEmail(projectName, emailSubscribe.email)
-          .then(() => undefined)
-          .catch((e) => {
-            defaultLog.error('Error sending welcome email:', e);
-            return Actions.sendResponse(res, 500, e);
-          });
-      }
-      // if not, resend the confirmation email for the new project
-      else {
-        defaultLog.info('Email NOT confirmed - sending confirm email for project/email', projectName, emailSubscribe.email);
-        Email.sendConfirmEmail(projectName, emailSubscribe.email, confirmKey)
-          .then(() => undefined)
-          .catch((e) => {
-            defaultLog.error('Error sending confirmation email:', e);
-            return Actions.sendResponse(res, 500, e);
-          });
-      }
-      return Actions.sendResponse(res, 200, entity);
-    }
-  
-    try {
-      var c = await emailSubscribe.save();
-      Utils.recordAction('Post', 'EmailSubscribe', 'public', c._id);
-      defaultLog.info('Saved new EmailSubscribe object:', c._id);
-      Email.sendConfirmEmail(projectName, emailSubscribe.email, c.confirmKey)
-        .then(() => Actions.sendResponse(res, 200, c))
-        .catch((e) => {throw new Error('Error sending confirmation email after save:', e)});
-    } catch (e) {
-      defaultLog.error('Error adding new email subscriber:', e);
-      return Actions.sendResponse(res, 500, e);
-    }
-  });
-};
-
-// confirm a new email address
-exports.unProtectedPut = async function (args, res) {
-  defaultLog.info('EMAIL SUBSCRIBE PUT');
-
-  // verify that the email and key have been set in the request
-  if (!(args.swagger.params.email && args.swagger.params.email.value) || !(args.swagger.params.confirmKey && args.swagger.params.confirmKey.value)) {
-    return Actions.sendResponse(res, 403, 'Access denied');
+  let requestedProjectId;
+  try {
+    requestedProjectId = mongoose.Types.ObjectId(obj.project);
+  } catch (err) {
+    defaultLog.warn('Invalid project identifier supplied for subscription', { email: requestedEmail, project: obj.project });
+    return sendGenericSuccess();
   }
-  
-  let emailAddress = args.swagger.params.email.value;
-  let confirmKey = args.swagger.params.confirmKey.value;
-  let emailId, correctConfirmKey, confirmDate, previousConfirmed, projectId;
-  let projectName = 'Planning in Partnership';
-  defaultLog.info('Put email subscribe:', emailAddress);
 
-  var EmailSubscribe = mongoose.model('EmailSubscribe');
-  var Project = mongoose.model('Project');
+  defaultLog.info('Incoming subscription request:', { email: requestedEmail, project: requestedProjectId });
 
-  // find the object ID based on the email address
-  await EmailSubscribe.findOne({ _schemaName: 'EmailSubscribe', email: emailAddress }, null, async function (err, entity) {
-    if (err) {
-      defaultLog.error('Error finding unconfirmed email subscription', e);
-      return Actions.sendResponse(res, 404, e);
-    }
+  const EmailSubscribe = mongoose.model('EmailSubscribe');
+  const Project = mongoose.model('Project');
 
-    if (entity) {
-      emailId = entity._id;
-      correctConfirmKey = entity.confirmKey;
-      confirmDate = new Date();
-      previousConfirmed = entity.confirmed;
-      projectId = entity.project;
-    }
+  try {
+    const now = new Date();
+    const requestedProject = await Project.findById(requestedProjectId).lean();
+    const requestedProjectName = requestedProject ? requestedProject.name : 'Planning in Partnership';
 
-    // check if the auth key is valid, else respond with a 403
-    if (correctConfirmKey !== confirmKey) {
-      defaultLog.info('Confirm key mismatch', confirmKey, correctConfirmKey);
-      defaultLog.info('HTTP request made with: ', confirmKey);
-      defaultLog.info('Retrieved confirmation key from the DB:', correctConfirmKey);
-      return Actions.sendResponse(res, 403, 'Access denied');
-    }
-c
-    // check if it has already been confirmed. If so, gracefully exit with a 200
-    if (previousConfirmed) {
-      defaultLog.info('Email has already been confirmed:', emailAddress);
-      return Actions.sendResponse(res, 200, {});
-    }
-
-    let emailSubscribe = {
-      confirmed: true,
-      dateConfirmed: confirmDate,
-    };
-
-    // get the project name
-    await Project.findOne({ _id: projectId }, null, async function (err, entity) {
-      if (err) defaultLog.error('Error getting project name. Will still attempt to send welcome email', err);
-      if (entity) {
-        projectName = entity.name;
-      }
+    let subscription = await EmailSubscribe.findOne({
+      _schemaName: 'EmailSubscribe',
+      email: requestedEmail
     });
 
-    defaultLog.info('Incoming updated object:', emailSubscribe);
+    // Case 1: No existing subscription - create new record and send confirmation email
+    if (!subscription) {
+      subscription = new EmailSubscribe({
+        _schemaName: 'EmailSubscribe',
+        email: requestedEmail,
+        project: [requestedProjectId],
+        confirmed: false,
+        dateSubscribed: now,
+        dateConfirmed: null,
+        read: ['staff', 'sysadmin'],
+        write: ['staff', 'sysadmin'],
+        delete: ['staff', 'sysadmin']
+      });
 
-    try {
-      let es = await EmailSubscribe.updateOne({ _id: emailId }, { $set: emailSubscribe });
-      Utils.recordAction('Put', 'EmailSubscribe', 'public', emailId);
-      defaultLog.info('Email confirmed:', emailId);
-      await Email.sendWelcomeEmail(projectName, emailAddress);
-      return Actions.sendResponse(res, 200, es);
-    } catch (e) {
-      defaultLog.error(e);
-      return Actions.sendResponse(res, 400, e);
+      const savedSubscription = await subscription.save();
+      Utils.recordAction('Post', 'EmailSubscribe', 'public', savedSubscription._id);
+      defaultLog.info('Created new email subscription:', savedSubscription._id);
+
+      const projectNames = await fetchProjectNames(Project, savedSubscription.project, requestedProjectName);
+      await Email.sendConfirmEmail(projectNames, requestedEmail, savedSubscription.confirmKey);
+      defaultLog.info('Sent confirmation email for new subscription', { email: requestedEmail, projects: projectNames });
+
+      return sendGenericSuccess();
     }
 
-  });
-}
+    const alreadySubscribedToProject = subscription.project.some(
+      projId => projId && projId.toString() === requestedProjectId.toString()
+    );
+
+    let subscriptionChanged = false;
+
+    if (!alreadySubscribedToProject) {
+      subscription.project.push(requestedProjectId);
+      subscriptionChanged = true;
+    }
+
+    // Handle unconfirmed subscriptions
+    if (!subscription.confirmed) {
+      const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+      const twentyFourHoursAgo = new Date(now.getTime() - TWENTY_FOUR_HOURS_MS);
+      const shouldSendConfirmEmail = !subscription.dateSubscribed || subscription.dateSubscribed <= twentyFourHoursAgo;
+
+      if (shouldSendConfirmEmail) {
+        const projectNames = await fetchProjectNames(Project, subscription.project, requestedProjectName);
+        await Email.sendConfirmEmail(projectNames, requestedEmail, subscription.confirmKey);
+        subscription.dateSubscribed = now;
+        subscriptionChanged = true;
+        defaultLog.info('Sent confirmation email for pending subscription', {
+          email: requestedEmail,
+          projectCount: projectNames.length,
+          subscriptionId: subscription._id
+        });
+      } else {
+        defaultLog.info('Confirmation email recently sent; skipping resend', {
+          subscriptionId: subscription._id,
+          lastSent: subscription.dateSubscribed
+        });
+      }
+
+      if (subscriptionChanged) {
+        await subscription.save();
+        Utils.recordAction('Put', 'EmailSubscribe', 'public', subscription._id);
+      }
+
+      return sendGenericSuccess();
+    }
+
+    // Handle confirmed subscriptions - send project added email for new project
+    if (!alreadySubscribedToProject) {
+      await subscription.save();
+      Utils.recordAction('Put', 'EmailSubscribe', 'public', subscription._id);
+      await Email.sendProjectAddedEmail([requestedProjectName], requestedEmail);
+      defaultLog.info('Sent project added email for confirmed subscriber joining new project', {
+        subscriptionId: subscription._id,
+        project: requestedProjectName
+      });
+    } else {
+      defaultLog.info('Confirmed subscriber attempted to re-subscribe to existing project', {
+        subscriptionId: subscription._id,
+        project: requestedProjectName
+      });
+    }
+
+    return sendGenericSuccess();
+
+  } catch (e) {
+    defaultLog.error('Error processing email subscription:', e);
+    return Actions.sendResponse(res, 500, { error: 'Internal server error' });
+  }
+};
+
+// Confirm a new email address
+exports.unProtectedPut = async function (args, res) {
+  defaultLog.info('EMAIL SUBSCRIBE PUT - Confirmation request');
+
+  // Validate required parameters
+  if (!(args.swagger.params.email && args.swagger.params.email.value) ||
+    !(args.swagger.params.confirmKey && args.swagger.params.confirmKey.value)) {
+    defaultLog.warn('Missing email or confirmation key in request');
+    return Actions.sendResponse(res, 403, 'Access denied');
+  }
+
+  const emailAddress = args.swagger.params.email.value;
+  const confirmKey = args.swagger.params.confirmKey.value;
+  const now = new Date();
+
+  defaultLog.info('Processing email confirmation', { email: emailAddress });
+
+  const EmailSubscribe = mongoose.model('EmailSubscribe');
+  const Project = mongoose.model('Project');
+
+  try {
+    const subscription = await EmailSubscribe.findOne({
+      _schemaName: 'EmailSubscribe',
+      email: emailAddress
+    });
+
+    if (!subscription) {
+      defaultLog.warn('No pending subscription found for confirmation attempt', { email: emailAddress });
+      return Actions.sendResponse(res, 404, 'Subscription not found');
+    }
+
+    if (subscription.confirmKey !== confirmKey) {
+      defaultLog.warn('Confirm key mismatch', {
+        email: emailAddress,
+        subscriptionId: subscription._id
+      });
+      return Actions.sendResponse(res, 403, 'Invalid confirmation key');
+    }
+
+    if (subscription.confirmed) {
+      defaultLog.info('Email already confirmed', { email: emailAddress, subscriptionId: subscription._id });
+      return Actions.sendResponse(res, 200, { message: 'Email already confirmed' });
+    }
+
+    // Confirm the subscription
+    subscription.confirmed = true;
+    subscription.dateConfirmed = now;
+    await subscription.save();
+
+    Utils.recordAction('Put', 'EmailSubscribe', 'public', subscription._id);
+
+    // Fetch project names and send welcome email
+    const projectNames = await fetchProjectNames(Project, subscription.project, 'Planning in Partnership');
+    await Email.sendWelcomeEmail(projectNames, emailAddress);
+
+    defaultLog.info('Email subscription confirmed successfully', {
+      subscriptionId: subscription._id,
+      projectCount: projectNames.length
+    });
+
+    return Actions.sendResponse(res, 200, { message: 'Subscription confirmed' });
+
+  } catch (e) {
+    defaultLog.error('Error confirming email subscription:', e);
+    return Actions.sendResponse(res, 500, { error: 'Internal server error' });
+  }
+};
 
 // unsubscribe from updates
 exports.unProtectedDelete = async function (args, res, next) {
@@ -241,26 +295,29 @@ exports.unProtectedDelete = async function (args, res, next) {
   }
 
   var emailAddress = args.swagger.params.email.value;
-  var emailId;
+  var emailIds;
   defaultLog.info('Delete email subscribe:', emailAddress);
 
   var EmailSubscribe = mongoose.model('EmailSubscribe');
 
-  // find the object ID based on the email address
-  await EmailSubscribe.findOne({ email: emailAddress }, null, function (err, entity) {
-    try {
-      emailId = entity._id;
-    } catch (e) {
-      defaultLog.error(e);
-      return Actions.sendResponse(res, 404, e);
+  // find the object ID(s) based on the email address
+  await EmailSubscribe.find({ _schemaName: 'EmailSubscribe', email: emailAddress }, null, function (err, entities) {
+    if (err) {
+      defaultLog.error('Error finding email subscribe object from email', err);
+      return Actions.sendResponse(res, 404, err);
+    }
+
+    if (entities) {
+      emailIds = entities.map(entity => entity._id);
     }
   });
 
   try {
-
-    var es = await EmailSubscribe.findOneAndRemove({ _id: emailId });
-    Utils.recordAction('Delete', 'EmailSubscribe', 'public', emailId);
-    defaultLog.info('Email unsubscribed:', es);
+    for (const emailId of emailIds) {
+      var es = await EmailSubscribe.findOneAndRemove({ _id: emailId });
+      Utils.recordAction('Delete', 'EmailSubscribe', 'public', emailId);
+      defaultLog.info('Email unsubscribed:', es);
+    }
     return Actions.sendResponse(res, 200, es);
   } catch (e) {
     defaultLog.error(e);
@@ -395,12 +452,12 @@ exports.protectedDelete = async function (args, res, next) {
 
       // check if project id is in project list
       const index = projectList.indexOf(projectId);
-      if ( index > -1) {
+      if (index > -1) {
         projectList.splice(index, 1);
-        if (projectList.length > 0 ) {
+        if (projectList.length > 0) {
           // update existing email object with new project list
           try {
-            var es = await EmailSubscribe.updateOne({ _id: emailId }, { $set: { project: projectList }});
+            var es = await EmailSubscribe.updateOne({ _id: emailId }, { $set: { project: projectList } });
             Utils.recordAction('Delete', 'EmailSubscribe', args.swagger.params.auth_payload.preferred_username, emailId);
             defaultLog.info('Email deleted from one project:', es);
             return Actions.sendResponse(res, 200, es);
@@ -425,7 +482,7 @@ exports.protectedDelete = async function (args, res, next) {
         defaultLog.info('Project ID not found: ', projectId);
         return Actions.sendResponse(res, 404, 'Project ID not found');
       }
-      
+
     }
   });
 
@@ -505,8 +562,8 @@ exports.handleContactFormResponse = async (args, res) => {
         return Actions.sendResponse(res, 400, { message: 'One or more files failed virus check.' });
       }
 
-      results.forEach((result) => {defaultLog.info('File passed virus scan:', result.file.originalname);});
-      
+      results.forEach((result) => { defaultLog.info('File passed virus scan:', result.file.originalname); });
+
     } catch (err) {
       defaultLog.error('Error during virus scanning:', err);
       return Actions.sendResponse(res, 500, { message: 'Virus scan failed unexpectedly.' });

--- a/api/helpers/email.js
+++ b/api/helpers/email.js
@@ -103,7 +103,12 @@ exports.sendConfirmEmail = async function (projectNames, email, confirmKey) {
     const { projectList } = buildProjectEmailContext(projectNames);
     const emailTemplate = {
         "bodyType": "text",
-        "body": "Please confirm your email address to receive updates from Planning In Partnership.\r\n\r\nYou are set to receive messages about:\r\n{{ projectList }}\r\n\r\nConfirm your subscription:\r\n{{ confirmHost }}confirm-email/{{ email }}/{{ confirmKey }}\r\n\r\nThis is an automatically generated email, please do not reply.\r\n\r\n",
+        "body": "Please confirm your email address to receive updates from Planning In Partnership.\r\n\r\n" +
+            "You are set to receive messages about:\r\n" +
+            "{{ projectList }}\r\n\r\n" +
+            "Confirm your subscription:\r\n" +
+            "{{ confirmHost }}confirm-email/{{ email }}/{{ confirmKey }}\r\n\r\n" +
+            "This is an automatically generated email, please do not reply.\r\n\r\n",
         "contexts": [
             {
                 "to": [email],
@@ -140,7 +145,12 @@ exports.sendWelcomeEmail = async function (projectNames, email) {
     const { projectList } = buildProjectEmailContext(projectNames);
     const emailTemplate = {
         "bodyType": "text",
-        "body": "Thank you for confirming your email address. You are now subscribed to updates for:\r\n{{ projectList }}\r\n\r\nYou will receive project updates directly to your inbox.\r\n\r\nIf at any time you want to unsubscribe, click the link below:\r\n{{ unsubcribeHost }}unsubscribe\r\n\r\nThis is an automatically generated email, please do not reply.\r\n\r\n",
+        "body": "Thank you for confirming your email address. You are now subscribed to updates for:\r\n" +
+            "{{ projectList }}\r\n\r\n" +
+            "You will receive project updates directly to your inbox.\r\n\r\n" +
+            "If at any time you want to unsubscribe, click the link below:\r\n" +
+            "{{ unsubcribeHost }}unsubscribe\r\n\r\n" +
+            "This is an automatically generated email, please do not reply.\r\n\r\n",
         "contexts": [
             {
                 "to": [email],
@@ -176,7 +186,12 @@ exports.sendProjectAddedEmail = async function (projectNames, email) {
     const { projectList } = buildProjectEmailContext(projectNames);
     const emailTemplate = {
         "bodyType": "text",
-        "body": "You have been added to updates for:\r\n{{ projectList }}\r\n\r\nYou will receive project updates directly to your inbox.\r\n\r\nIf at any time you want to unsubscribe, click the link below:\r\n{{ unsubcribeHost }}unsubscribe\r\n\r\nThis is an automatically generated email, please do not reply.\r\n\r\n",
+        "body": "You have been added to updates for:\r\n" +
+            "{{ projectList }}\r\n\r\n" +
+            "You will receive project updates directly to your inbox.\r\n\r\n" +
+            "If at any time you want to unsubscribe, click the link below:\r\n" +
+            "{{ unsubcribeHost }}unsubscribe\r\n\r\n" +
+            "This is an automatically generated email, please do not reply.\r\n\r\n",
         "contexts": [
             {
                 "to": [email],

--- a/api/helpers/email.js
+++ b/api/helpers/email.js
@@ -25,7 +25,7 @@ if (_EMAIL_CLIENT_SECRET === null) {
     defaultLog.error('*******************************************************************');
 }
 
-const getEmailToken = async function() {
+const getEmailToken = async function () {
     return await axios.post(_CHES_AUTH_ENDPOINT,
         qs.stringify({
             'client_id': _EMAIL_CLIENTID,
@@ -38,18 +38,77 @@ const getEmailToken = async function() {
             }
         }
     );
-}
+};
 
-exports.sendConfirmEmail = async function ( projectName, email, confirmKey) {
-    // Set/Get the template
-    let emailTemplate = {
+/**
+ * Build formatted project list for email templates.
+ * 
+ * @param {string[]} projectNames Array of project names
+ * @returns {object} Object containing formatted projectList string
+ */
+const buildProjectEmailContext = (projectNames) => {
+    const names = Array.isArray(projectNames) ? projectNames.filter(Boolean) : [];
+    const projectList = names.length > 0
+        ? names.map(name => `- ${name}`).join('\r\n')
+        : '- Planning In Partnership';
+
+    return { projectList };
+};
+
+/**
+ * Send an email using the CHES API.
+ * 
+ * @param {object} emailTemplate The email template used by the CHES API
+ * @returns {Promise<void>}
+ */
+const sendEmailViaCHES = async (emailTemplate) => {
+    try {
+        const emailToken = await getEmailToken();
+
+        if (emailToken && emailToken.data && emailToken.data.access_token) {
+            const response = await axios.post(
+                _commonHostingEmailServiceEndpoint + _CHES_emailMergeAPI,
+                emailTemplate,
+                {
+                    headers: {
+                        "Authorization": 'Bearer ' + emailToken.data.access_token,
+                        "Content-Type": 'application/json'
+                    }
+                }
+            );
+            defaultLog.info('Email sent successfully via CHES', {
+                to: emailTemplate.contexts[0].to,
+                subject: emailTemplate.subject
+            });
+            return response;
+        } else {
+            defaultLog.error("Couldn't get a valid CHES token", emailToken);
+            throw new Error('Failed to obtain CHES authentication token');
+        }
+    } catch (err) {
+        defaultLog.error('Error sending email via CHES:', err);
+        throw err;
+    }
+};
+
+/**
+ * Send confirmation email for email subscription.
+ * 
+ * @param {string[]} projectNames Array of project names the user is subscribing to
+ * @param {string} email Email address to send confirmation to
+ * @param {string} confirmKey Unique confirmation key for verifying the subscription
+ * @returns {Promise<void>}
+ */
+exports.sendConfirmEmail = async function (projectNames, email, confirmKey) {
+    const { projectList } = buildProjectEmailContext(projectNames);
+    const emailTemplate = {
         "bodyType": "text",
-        "body": "Please click the following link to confirm your email address\r\n\r\n {{ confirmHost }}confirm-email/{{ email }}/{{ confirmKey }} \r\n\r\nThis is an automatically generated email, please do not reply.\r\n\r\n",
+        "body": "Please confirm your email address to receive updates from Planning In Partnership.\r\n\r\nYou are set to receive messages about:\r\n{{ projectList }}\r\n\r\nConfirm your subscription:\r\n{{ confirmHost }}confirm-email/{{ email }}/{{ confirmKey }}\r\n\r\nThis is an automatically generated email, please do not reply.\r\n\r\n",
         "contexts": [
             {
                 "to": [email],
                 "context": {
-                    "projectName": projectName,
+                    "projectList": projectList,
                     "confirmKey": confirmKey,
                     "confirmHost": _publicServiceEndpoint,
                     "email": email
@@ -57,134 +116,115 @@ exports.sendConfirmEmail = async function ( projectName, email, confirmKey) {
             }
         ],
         "encoding": "utf-8",
-        "from": "BC Gov Land Use Planning <noreply@gov.bc.ca>",
+        "from": "BC Gov Planning In Partnership <noreply@gov.bc.ca>",
         "priority": "normal",
-        "subject": "Confirming your email for the {{ projectName }} distribution list"
+        "subject": "Confirm your Planning In Partnership email subscription"
     };
 
-    // Send the emails to the CHES (Common Hosted Email Service)
     try {
-        const emailToken = await getEmailToken();
-
-        if (emailToken && emailToken.data && emailToken.data.access_token) {
-            // Send the confirm email
-            await axios.post(
-                _commonHostingEmailServiceEndpoint + _CHES_emailMergeAPI,
-                emailTemplate,
-                {
-                    headers: {
-                        "Authorization": 'Bearer ' + emailToken.data.access_token,
-                        "Content-Type": 'application/json'
-                    }
-                }
-            );
-            defaultLog.info("Email Sent");
-        } else {
-            defaultLog.error("Couldn't get a proper token", emailToken);
-        }
+        await sendEmailViaCHES(emailTemplate);
     } catch (err) {
-        defaultLog.error("Error:", err);
-        // fall through, don't block execution on this.
+        defaultLog.error('Failed to send confirmation email:', { email, error: err.message });
+        // Don't throw - allow the subscription process to continue even if email fails
     }
-
-    return;
 };
 
-exports.sendWelcomeEmail = async function (projectName, email) {
-    // Set/Get the template
-    let emailTemplate = {
+/**
+ * Send welcome email after subscription confirmation.
+ * 
+ * @param {string[]} projectNames Array of project names the user is subscribed to
+ * @param {string} email Email address to send welcome message to
+ * @returns {Promise<void>}
+ */
+exports.sendWelcomeEmail = async function (projectNames, email) {
+    const { projectList } = buildProjectEmailContext(projectNames);
+    const emailTemplate = {
         "bodyType": "text",
-        "body": "Thank you for signing up. Your email has been added to the {{ projectName }} distribution list and you are now set up to receive project updates directly to your inbox.\r\n\r\nIf at any time you want to unsubscribe, click the link below.\r\n\r\n{{ unsubcribeHost }}unsubscribe\r\n\r\nThis is an automatically generated email, please do not reply.\r\n\r\n",
+        "body": "Thank you for confirming your email address. You are now subscribed to updates for:\r\n{{ projectList }}\r\n\r\nYou will receive project updates directly to your inbox.\r\n\r\nIf at any time you want to unsubscribe, click the link below:\r\n{{ unsubcribeHost }}unsubscribe\r\n\r\nThis is an automatically generated email, please do not reply.\r\n\r\n",
         "contexts": [
             {
                 "to": [email],
                 "context": {
-                    "projectName": projectName,
+                    "projectList": projectList,
                     "unsubcribeHost": _publicServiceEndpoint,
                     "email": email
                 }
             }
         ],
         "encoding": "utf-8",
-        "from": "BC Gov Land Use Planning  <noreply@gov.bc.ca>",
+        "from": "BC Gov Planning In Partnership <noreply@gov.bc.ca>",
         "priority": "normal",
-        "subject": "Welcome to the {{ projectName }} distribution list"
+        "subject": "Welcome to Planning In Partnership updates"
     };
 
-    // Send the emails to the CHES (Common Hosted Email Service)
     try {
-        const emailToken = await getEmailToken();
-
-        if (emailToken && emailToken.data && emailToken.data.access_token) {
-            // Send the welcome email
-            await axios.post(
-                _commonHostingEmailServiceEndpoint + _CHES_emailMergeAPI,
-                emailTemplate,
-                {
-                    headers: {
-                        "Authorization": 'Bearer ' + emailToken.data.access_token,
-                        "Content-Type": 'application/json'
-                    }
-                }
-            );
-            defaultLog.info("Email Sent");
-        } else {
-            defaultLog.error("Couldn't get a proper token", emailToken);
-        }
+        await sendEmailViaCHES(emailTemplate);
     } catch (err) {
-        defaultLog.error("Error:", err);
-        // fall through, don't block execution on this.
+        defaultLog.error('Failed to send welcome email:', { email, error: err.message });
+        // Don't throw - allow the confirmation process to complete even if email fails
     }
-
-    return;
 };
 
 /**
- * Contact the CHES API service to get a valid token, then send an email.
+ * Send project added email for users who are already confirmed and subscribing to an additional project.
  * 
- * @param {object} emailTemplate The email template used by the CHES API.
- * @returns {void}
+ * @param {string[]} projectNames Array of project names (typically just the new project)
+ * @param {string} email Email address to send notification to
+ * @returns {Promise<void>}
+ */
+exports.sendProjectAddedEmail = async function (projectNames, email) {
+    const { projectList } = buildProjectEmailContext(projectNames);
+    const emailTemplate = {
+        "bodyType": "text",
+        "body": "You have been added to updates for:\r\n{{ projectList }}\r\n\r\nYou will receive project updates directly to your inbox.\r\n\r\nIf at any time you want to unsubscribe, click the link below:\r\n{{ unsubcribeHost }}unsubscribe\r\n\r\nThis is an automatically generated email, please do not reply.\r\n\r\n",
+        "contexts": [
+            {
+                "to": [email],
+                "context": {
+                    "projectList": projectList,
+                    "unsubcribeHost": _publicServiceEndpoint,
+                    "email": email
+                }
+            }
+        ],
+        "encoding": "utf-8",
+        "from": "BC Gov Planning In Partnership <noreply@gov.bc.ca>",
+        "priority": "normal",
+        "subject": "You've been added to new Planning In Partnership project updates"
+    };
+
+    try {
+        await sendEmailViaCHES(emailTemplate);
+    } catch (err) {
+        defaultLog.error('Failed to send project added email:', { email, error: err.message });
+        // Don't throw - allow the subscription process to complete even if email fails
+    }
+};
+
+/**
+ * Send an email using the CHES API (used for contact form emails).
+ * 
+ * @param {object} emailTemplate The email template used by the CHES API
+ * @returns {Promise<void>}
  */
 const sendEmail = async (emailTemplate) => {
     try {
-        // Retrieve and validate token
-        const emailToken = await getEmailToken();
-        let token;
-        if (emailToken && emailToken.data && emailToken.data.access_token) {
-            token = emailToken.data.access_token;
-        }
-        if (!token) {
-            defaultLog.error("Couldn't get a valid CHES token", emailToken);
-            return;
-        }
-
-        // Send confirmation email to user.
-        const response = await axios.post(
-            _commonHostingEmailServiceEndpoint + _CHES_emailMergeAPI,
-            emailTemplate,
-            {
-                headers: {
-                    "Authorization": `Bearer ${token}`,
-                    "Content-Type": 'application/json'
-                }
-            }
-        );
-
-        defaultLog.info('Email sent:', response.data);
+        await sendEmailViaCHES(emailTemplate);
     } catch (error) {
-        defaultLog.error('Ches rejected the email:', error);
+        defaultLog.error('Failed to send email:', error);
+        // Don't throw - log the error but allow execution to continue
     }
-}
+};
 
 /**
  * Build the email template used by the CHES API.
  * 
- * @param {string} subject The email subject line.
- * @param {string} body The body of the email.
- * @param {array} toAddresses An array of email addresses to send to.
- * @param {string} fromAddress The email address to mark as "from".
- * @param {object[]} attachments The attachments to send with the email.
- * @returns {object}
+ * @param {string} subject The email subject line
+ * @param {string} body The body of the email
+ * @param {string[]} toAddresses An array of email addresses to send to
+ * @param {string} fromAddress The email address to mark as "from"
+ * @param {object[]} attachments The attachments to send with the email
+ * @returns {object} Email template object for CHES API
  */
 const buildEmailTemplate = (subject, body, toAddresses, fromAddress, attachments = null) => {
     const emailTemplate = {
@@ -200,55 +240,69 @@ const buildEmailTemplate = (subject, body, toAddresses, fromAddress, attachments
         "from": fromAddress,
         "priority": "normal",
         "subject": subject,
-    }
+    };
 
-    // Add files if they are present
     if (Array.isArray(attachments) && attachments.length > 0) {
         emailTemplate.attachments = attachments;
     }
 
     return emailTemplate;
-}
+};
 
+/**
+ * Handle contact form submission by sending confirmation and notification emails.
+ * 
+ * @param {string} projectName Name of the project the contact form is for
+ * @param {object} contactFormResponse Contact form data (name, email, message, files)
+ * @param {string[]} recipients Array of email addresses to notify
+ * @returns {Promise<void>}
+ */
 exports.handleContactFormResponse = async (projectName, contactFormResponse, recipients) => {
-    if (!Array.isArray(recipients) || (Array.isArray(recipients) && recipients.length === 0)) {
-        throw Error('Invalid recipients. Could not send email.');
+    if (!Array.isArray(recipients) || recipients.length === 0) {
+        throw new Error('Invalid recipients. Could not send email.');
     }
-    // Build the email template to send to the user as confirmation.
+
+    // Build the email template to send to the user as confirmation
     const confirmationToAddresses = [contactFormResponse.email];
     const confirmationSubject = `Contact us message received for ${projectName}`;
-    const confirmationBody = `Thank you for contacting the ${projectName} project team! We'll respond to your request shortly.`
+    const confirmationBody = `Thank you for contacting the ${projectName} project team! We'll respond to your request shortly.`;
     const confirmationFromAddress = recipients[0];
-    const confirmationEmailTemplate = buildEmailTemplate(confirmationSubject, confirmationBody, confirmationToAddresses, confirmationFromAddress);
+    const confirmationEmailTemplate = buildEmailTemplate(
+        confirmationSubject,
+        confirmationBody,
+        confirmationToAddresses,
+        confirmationFromAddress
+    );
 
-    // Build the email template to send to the project leads.
+    // Build the email template to send to the project leads
     const formSubmissionToAddresses = recipients;
     const formSubmissionSubject = `New message received for the ${projectName} project`;
-    const formSubmissionBody = `You've received the following message from ${contactFormResponse.name}: ${contactFormResponse.message}`;
+    const formSubmissionBody = `You've received the following message from ${contactFormResponse.name}:\r\n\r\n${contactFormResponse.message}`;
     const formSubmissionFromAddress = contactFormResponse.email;
-    const formSubmissionAttachments = contactFormResponse.files ? contactFormResponse.files.map(file => {
-        return {
+    const formSubmissionAttachments = contactFormResponse.files
+        ? contactFormResponse.files.map(file => ({
             filename: file.originalname,
             content: file.buffer.toString('base64'),
             encoding: 'base64',
             contentType: file.mimetype
-        }
-    }) : null;
+        }))
+        : null;
     const formSubmissionTemplate = buildEmailTemplate(
-        formSubmissionSubject, 
-        formSubmissionBody, 
-        formSubmissionToAddresses, 
+        formSubmissionSubject,
+        formSubmissionBody,
+        formSubmissionToAddresses,
         formSubmissionFromAddress,
-        formSubmissionAttachments || null
+        formSubmissionAttachments
     );
 
-    // Send the emails to the CHES (Common Hosted Email Service).
+    // Send the emails to the CHES (Common Hosted Email Service)
     try {
-        sendEmail(confirmationEmailTemplate);
-        sendEmail(formSubmissionTemplate);
+        await Promise.all([
+            sendEmail(confirmationEmailTemplate),
+            sendEmail(formSubmissionTemplate)
+        ]);
     } catch (e) {
-        defaultLog.error("Error sending emails:", e);
+        defaultLog.error('Error sending contact form emails:', e);
+        throw e;
     }
-
-    return;
 };


### PR DESCRIPTION
* Update email subscribe confirmation ([DESENG-921](https://citz-gdx.atlassian.net/browse/DESENG-921))
    * Fix an issue where subscribing to multiple projects would create invalid confirmation links
    * Finish implementation of adding projects to existing confirmed subscriptions
    * Send "project added" email when a confirmed subscriber adds a new project
    * Update email templates to clarify what action the user is taking
    * Clean up existing code, comments, and logging in email.js and emailSubscribe.js