### PR TITLE
DESENG-917: Add dynamic sitemap generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+### Nov 13, 2025
+* Add dynamic sitemap generation for projects and comment periods [DESENG-917](https://citz-gdx.atlassian.net/browse/DESENG-917)
+    * New endpoint at `/api/sitemap_dynamic.xml` (static pages remain at `/sitemap.xml`)
+    * Includes all publicly accessible projects and published comment periods
+    * Automatically generated from the database with relevant SEO metadata
+
+### Nov 5, 2025
+* Update email subscribe confirmation ([DESENG-921](https://citz-gdx.atlassian.net/browse/DESENG-921))
+    * Fix an issue where subscribing to multiple projects would create invalid confirmation links
+    * Finish implementation of adding projects to existing confirmed subscriptions
+    * Send "project added" email when a confirmed subscriber adds a new project
+    * Update email templates to clarify what action the user is taking
+    * Clean up existing code, comments, and logging in email.js and emailSubscribe.js
+
+### Oct 31, 2025
+* Added the ability to remove a user from the permissions list. [DESENG-881](https://citz-gdx.atlassian.net/browse/DESENG-881)
+
 ### Aug 26, 2025
 * Fixed API state hang that prevents container restarts when a fatal error occurs. [DESENG-889](https://citz-gdx.atlassian.net/browse/DESENG-889)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Nov 13, 2025
 * Add dynamic sitemap generation for projects and comment periods [DESENG-917](https://citz-gdx.atlassian.net/browse/DESENG-917)
-    * New endpoint at `/api/sitemap_dynamic.xml` (static pages remain at `/sitemap.xml`)
+    * New endpoint at `/api/sitemap_dynamic.xml` (linked by reference from `/sitemap.xml` on the webapp side)
     * Includes all publicly accessible projects and published comment periods
     * Automatically generated from the database with relevant SEO metadata
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ This project uses npm package `swagger-tools` via `./app.js` to automatically ge
 
 Recommend reviewing the [Open API Specification](https://swagger.io/docs/specification/about/) before making any changes to the `swagger.yaml` file.
 
+### Dynamic Sitemap
+
+The API provides a dynamic sitemap at `/api/sitemap_dynamic.xml` that includes:
+- All publicly accessible projects
+- All published comment periods
+
+The sitemap is automatically generated from the database and includes:
+- URLs for project detail pages
+- URLs for comment period pages
+- Last modification dates
+- Change frequency hints
+- Priority indicators for SEO
+
 
 #### Seed with generated data:
 

--- a/api/controllers/sitemap.js
+++ b/api/controllers/sitemap.js
@@ -1,0 +1,74 @@
+const defaultLog = require('winston').loggers.get('defaultLog');
+const mongoose = require('mongoose');
+
+/**
+ * Generate a dynamic sitemap for all non-static pages
+ */
+exports.getDynamicSitemap = async function (req, res) {
+    defaultLog.info('DYNAMIC SITEMAP GET');
+
+    try {
+        const Project = mongoose.model('Project');
+        const CommentPeriod = mongoose.model('CommentPeriod');
+
+        // Query for all projects that are publicly accessible
+        const projects = await Project.find({
+            read: { $in: ['public'] }
+        })
+            .select('_id name dateUpdated dateAdded')
+            .sort({ dateUpdated: -1 })
+            .lean();
+
+        // Query for published comment periods
+        const commentPeriods = await CommentPeriod.find({
+            isPublished: true
+        })
+            .select('_id project phaseName dateUpdated dateAdded')
+            .populate('project', '_id')
+            .sort({ dateUpdated: -1 })
+            .lean();
+
+        // Start building the XML sitemap
+        let sitemap = '<?xml version="1.0" encoding="UTF-8"?>\n';
+        sitemap += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
+
+        // Add each project to the sitemap
+        projects.forEach(project => {
+            const lastModDate = project.dateUpdated || project.dateAdded || new Date();
+            const formattedDate = new Date(lastModDate).toISOString().split('T')[0];
+
+            sitemap += `  <url>\n`;
+            sitemap += `    <loc>https://planninginpartnership.ca/p/${project._id}/project-details</loc>\n`;
+            sitemap += `    <lastmod>${formattedDate}</lastmod>\n`;
+            sitemap += `    <changefreq>weekly</changefreq>\n`;
+            sitemap += `    <priority>0.8</priority>\n`;
+            sitemap += `  </url>\n`;
+        });
+
+        // Add comment periods to the sitemap
+        commentPeriods.forEach(commentPeriod => {
+            if (commentPeriod.project && commentPeriod.project._id) {
+                const lastModDate = commentPeriod.dateUpdated || commentPeriod.dateAdded || new Date();
+                const formattedDate = new Date(lastModDate).toISOString().split('T')[0];
+
+                sitemap += `  <url>\n`;
+                sitemap += `    <loc>https://planninginpartnership.ca/p/${commentPeriod.project._id}/cp/${commentPeriod._id}</loc>\n`;
+                sitemap += `    <lastmod>${formattedDate}</lastmod>\n`;
+                sitemap += `    <changefreq>weekly</changefreq>\n`;
+                sitemap += `    <priority>0.7</priority>\n`;
+                sitemap += `  </url>\n`;
+            }
+        });
+
+        sitemap += '</urlset>';
+
+        // Set the appropriate headers and send the response
+        res.header('Content-Type', 'application/xml');
+        res.status(200).send(sitemap);
+
+        defaultLog.info(`Generated dynamic sitemap with ${projects.length} projects and ${commentPeriods.length} comment periods`);
+    } catch (error) {
+        defaultLog.error('Error generating dynamic sitemap:', error);
+        res.status(500).send('<?xml version="1.0" encoding="UTF-8"?>\n<error>Failed to generate sitemap</error>');
+    }
+};

--- a/api/controllers/sitemap.js
+++ b/api/controllers/sitemap.js
@@ -36,13 +36,32 @@ exports.getDynamicSitemap = async function (req, res) {
         projects.forEach(project => {
             const lastModDate = project.dateUpdated || project.dateAdded || new Date();
             const formattedDate = new Date(lastModDate).toISOString().split('T')[0];
+            const baseUrl = `https://planninginpartnership.ca/p/${project._id}`;
 
+            // Main project details page
             sitemap += `  <url>\n`;
-            sitemap += `    <loc>https://planninginpartnership.ca/p/${project._id}/project-details</loc>\n`;
+            sitemap += `    <loc>${baseUrl}/project-details</loc>\n`;
             sitemap += `    <lastmod>${formattedDate}</lastmod>\n`;
             sitemap += `    <changefreq>weekly</changefreq>\n`;
             sitemap += `    <priority>0.8</priority>\n`;
             sitemap += `  </url>\n`;
+
+            // Project tab pages
+            const projectTabs = [
+                { path: 'background-info', priority: '0.7' },
+                { path: 'commenting', priority: '0.75' },
+                { path: 'documents', priority: '0.75' },
+                { path: 'project-phase', priority: '0.7' }
+            ];
+
+            projectTabs.forEach(tab => {
+                sitemap += `  <url>\n`;
+                sitemap += `    <loc>${baseUrl}/${tab.path}</loc>\n`;
+                sitemap += `    <lastmod>${formattedDate}</lastmod>\n`;
+                sitemap += `    <changefreq>weekly</changefreq>\n`;
+                sitemap += `    <priority>${tab.priority}</priority>\n`;
+                sitemap += `  </url>\n`;
+            });
         });
 
         // Add comment periods to the sitemap

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -794,6 +794,24 @@ paths:
         '500':
           description: API is unhealthy
 
+  /sitemap_dynamic.xml:
+    get:
+      summary: Dynamic sitemap for non-static pages
+      description: Returns an XML sitemap containing all publicly accessible projects
+      x-swagger-router-controller: sitemap
+      operationId: getDynamicSitemap
+      tags:
+        - sitemap
+      produces:
+        - application/xml
+      responses:
+        '200':
+          description: Successfully generated sitemap
+          schema:
+            type: string
+        '500':
+          description: Error generating sitemap
+
 ### Project Routes
   /project:
     x-swagger-router-controller: project


### PR DESCRIPTION
* Add dynamic sitemap generation for projects and comment periods [DESENG-917](https://citz-gdx.atlassian.net/browse/DESENG-917)
    * New endpoint at `/api/sitemap_dynamic.xml` (static pages remain at `/sitemap.xml`)
    * Includes all publicly accessible projects and published comment periods
    * Automatically generated from the database with relevant SEO metadata