### PR TITLE
bugfix/deseng959: Removing index syncing after it failed in dev environment due to existing duplicates on unique index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Apr 29, 2026
-* Modified app.js to add authSource and sync indexes.
+* Modified app.js to add authSource.
 
 ### Apr 24, 2026
 * Added an additional field to comment period objects for external tool popup URL [DESENG-959](https://citz-gdx.atlassian.net/browse/DESENG-959)

--- a/app.js
+++ b/app.js
@@ -126,7 +126,6 @@ swaggerTools.initializeMiddleware(swaggerConfig, function(middleware) {
     require('./api/helpers/models/commentperiod');
     require('./api/helpers/models/topic');
     require('./api/helpers/models/emailSubscribe');
-    await mongoose.connection.syncIndexes();
     defaultLog.info('db model loading done.');
 
     // Build text index.


### PR DESCRIPTION
- Removing index syncing after it failed in dev environment due to existing duplicates on unique index.