### PR TITLE
feature/deseng965: Fixed document protected put controller logic so that it doesn't update document visibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Jun 26, 2026
+* Removed publishing/visibility updates on protected document put. These are handled outside of form submission.
+
 ### Apr 29, 2026
 * Modified app.js to add authSource.
 

--- a/api/controllers/document.js
+++ b/api/controllers/document.js
@@ -728,7 +728,6 @@ exports.protectedPut = async (args, res) => {
   defaultLog.info('DOCUMENT PROTECTED PUT');
   const objId = params.docId.value;
   defaultLog.info('Put document:', objId);
-  defaultLog.info('PARAM CHECK FOR PUBLISHED STRING, is it Published?', params.eaoStatus.value === 'Published')
 
   const patch = {
     _updatedBy: params.auth_payload.preferred_username,

--- a/api/controllers/document.js
+++ b/api/controllers/document.js
@@ -728,6 +728,7 @@ exports.protectedPut = async (args, res) => {
   defaultLog.info('DOCUMENT PROTECTED PUT');
   const objId = params.docId.value;
   defaultLog.info('Put document:', objId);
+  defaultLog.info('PARAM CHECK FOR PUBLISHED STRING, is it Published?', params.eaoStatus.value === 'Published')
 
   const patch = {
     _updatedBy: params.auth_payload.preferred_username,
@@ -739,12 +740,6 @@ exports.protectedPut = async (args, res) => {
     datePosted: params.datePosted.value,
     description: params.description.value,
     keywords: params.keywords.value,
-    eaoStatus: params.eaoStatus.value,
-    read: [
-      'staff',
-      'sysadmin',
-      params.eaoStatus.value === 'Published' ? 'public' : undefined,
-    ],
   };
 
   const Document = mongoose.model('Document');


### PR DESCRIPTION
### Jun 26, 2026
* Removed publishing/visibility updates on protected document put. These are handled outside of document update form submission.